### PR TITLE
Display newlines

### DIFF
--- a/extension/js/workerFormatter.js
+++ b/extension/js/workerFormatter.js
@@ -13,7 +13,8 @@ function htmlEncode(t) {
         .replace(/"/g, '&quot;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
-        .replace(/ /g, '&nbsp;');
+        .replace(/ /g, '&nbsp;')
+        .replace(/\n/g, '<br>');
 }
 
 function decorateWithSpan(value, className) {


### PR DESCRIPTION
With this PR newlines are replaced with \<br> so that they are visible to the viewer. Would be awesome if you could merge and publish this so that I don't need to publish another version of this on the chrome web store :+1: 