### PR TITLE
remove load console logs

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -457,7 +457,6 @@ function stripJsonPrefix(text) {
 }
 
 function load() {
-    console.log('JSON Viewer load start')
     if (document.body &&
         (
             document.body.firstElementChild &&
@@ -471,7 +470,6 @@ function load() {
         console.log({rawData: data})
         if (data) init(data)
     }
-    console.log('JSON Viewer load end')
 }
 
 document.addEventListener('DOMContentLoaded', load)


### PR DESCRIPTION
Are these `console.log` statements necessary, or do you mind if they're removed? They're showing up every time the web inspector is opened, regardless of whether or not the page is JSON.